### PR TITLE
Fix typo in fulltext_index_name in  hybrid_retriever.py

### DIFF
--- a/2-neo4j-graphrag/solutions/hybrid_retriever.py
+++ b/2-neo4j-graphrag/solutions/hybrid_retriever.py
@@ -23,7 +23,7 @@ from neo4j_graphrag.llm import OpenAILLM
 retriever = HybridRetriever(
     driver=driver,
     vector_index_name="moviePlots",
-    fulltext_index_name="plotFullText",
+    fulltext_index_name="plotFulltext",
     embedder=embedder,
     return_properties=["title", "plot"],
 )


### PR DESCRIPTION
Fix the typo: It should be plotFulltext not plotFullText